### PR TITLE
CI/CD: Release Pipeline with GoReleaser

### DIFF
--- a/.github/workflow/release.yml
+++ b/.github/workflow/release.yml
@@ -7,18 +7,13 @@ on:
       # v1.0.0, v1.0.1, ...
       - 'v*'
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-    # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+permissions:
+      contents: write
+      packages: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
     steps:
       -
         name: Checkout
@@ -40,3 +35,5 @@ jobs:
         env:
           # Pass the GitHub token to GoReleaser
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass the registry and image name to GoReleaser
+          KO_DOCKER_REPO: ghcr.io/bluewave-labs/capture

--- a/.github/workflow/release.yml
+++ b/.github/workflow/release.yml
@@ -1,0 +1,42 @@
+name: release
+
+on:
+  push:
+    tags:
+      # It will be triggered when a new tag starting with 'v' is pushed
+      # v1.0.0, v1.0.1, ...
+      - 'v*'
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+    # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.1
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          # Pass the GitHub token to GoReleaser
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+version: 2
+project_name: bwuagent
+
+builds:
+  - id: bwuagent
+    main: ./cmd/api
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      # Support multiple cpu architectures
+      - amd64
+      - arm64
+    ignore:
+      # Ignore the arm64 build on windows
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  # Generate checksum files to confirm the integrity of the files.
+  # `sha256sum <file>`
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+changelog:
+  sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,6 @@ kos:
     ldflags:
       - -s -w
       - -extldflags "-static"
-      - -X main.Version={{.Tag}}
     creation_time: "{{.CommitTimestamp}}"
     sbom: spdx
     env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,9 @@
 version: 2
-project_name: bwuagent
+project_name: capture
 
 builds:
-  - id: bwuagent
-    main: ./cmd/api
+  - id: capture
+    main: ./cmd/capture
     env:
       - CGO_ENABLED=0
     goos:
@@ -20,6 +20,28 @@ builds:
       - goos: windows
         goarch: arm64
 
+kos:
+  - id: capture
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - latest
+      - '{{.Tag}}'
+    main: ./cmd/capture
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -extldflags "-static"
+      - -X main.Version={{.Tag}}
+    creation_time: "{{.CommitTimestamp}}"
+    sbom: spdx
+    env:
+      - CGO_ENABLED=0
+    bare: true
+    
+
 archives:
   - format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
@@ -35,3 +57,7 @@ checksum:
 
 changelog:
   sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,8 +8,9 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
-      - darwin
+      # Disable windows and darwin builds for now, because the app is not working on these platforms
+      # - windows
+      # - darwin
     goarch:
       # Support multiple cpu architectures
       - amd64


### PR DESCRIPTION
Issue: #23 

- [x] Run when someone push tag starts with `v*` (Not tested)
- [x] Build the app in different os and archs (Tested manually) | Disabled windows and macos releases for now.
- [x] Generate checksums for the artifacts (Tested manually)
- [x] Create a new release page on GitHub (Not tested)
- [x] Build the image with ko | (Not tested)
- [x] Push image to the **ghcr**(GitHub Container Registry)  | (Not tested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated release workflow for Go applications.
	- Added configuration for building and releasing the `capture` application.

- **Documentation**
	- Updated settings for generating checksums and changelogs.

- **Chores**
	- Created a new workflow file for managing releases.
	- Configured build targets and output formats for artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->