### PR TITLE
fix(config): Remove allowPublicApi param from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,17 +147,16 @@ Capture is a set of tools running on the server and providing information about 
 
 6. Environment Variables
 
-    If you want to change the port, api secret or allow public api, you can use this environment variables.
+    If you want to change port or the api secret you can use this environment variables.
 
     ```shell
     PORT = your_port
     API_SECRET = your_secret
-    ALLOW_PUBLIC_API = true/false
     GIN_MODE = release/debug
     ```
 
     Usage:
 
     ```shell
-    PORT=8080 API_SECRET=your_secret ALLOW_PUBLIC_API=true GIN_MODE=release ./capture
+    PORT=8080 API_SECRET=your_secret GIN_MODE=release ./capture
     ```

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Capture is a set of tools running on the server and providing information about 
 
 6. Environment Variables
 
-    If you want to change port or the api secret you can use this environment variables.
+    If you want to change the port or the API secret, you can use these environment variables:
 
     ```shell
     PORT = your_port
@@ -158,5 +158,9 @@ Capture is a set of tools running on the server and providing information about 
     Usage:
 
     ```shell
+    # API_SECRET is required
     PORT=8080 API_SECRET=your_secret GIN_MODE=release ./capture
+
+    # Minimal required configuration
+    API_SECRET=your_secret ./capture
     ```

--- a/cmd/capture/main.go
+++ b/cmd/capture/main.go
@@ -18,7 +18,6 @@ import (
 var appConfig = config.NewConfig(
 	os.Getenv("PORT"),
 	os.Getenv("API_SECRET"),
-	os.Getenv("ALLOW_PUBLIC_API"),
 )
 
 func main() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ func NewConfig(port string, apiSecret string) *Config {
 
 	// Print error message if API_SECRET is not provided
 	if apiSecret == "" {
-		log.Fatalln("API_SECRET is required")
+		log.Fatalln("API_SECRET environment variable is required for security purposes. Please set it before starting the server.")
 	}
 
 	return &Config{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,44 +1,34 @@
 package config
 
-import (
-	"errors"
-	"log"
-)
+import "log"
 
 type Config struct {
-	Port           string
-	ApiSecret      string
-	AllowPublicApi bool
+	Port      string
+	ApiSecret string
 }
 
-var isPublicApiAllowed bool
 var defaultPort = "59232"
 
-func NewConfig(port string, apiSecret string, allowPublicApi string) *Config {
+func NewConfig(port string, apiSecret string) *Config {
 	// Set default port if not provided
 	if port == "" {
 		port = defaultPort
 	}
 
-	if allowPublicApi == "true" {
-		isPublicApiAllowed = true
-	} else if allowPublicApi == "false" || allowPublicApi == "" {
-		isPublicApiAllowed = false
-	} else {
-		log.Panic(errors.New("Invalid bool value on AllowPublicApi"))
+	// Print error message if API_SECRET is not provided
+	if apiSecret == "" {
+		log.Fatalln("API_SECRET is required")
 	}
 
 	return &Config{
-		Port:           port,
-		ApiSecret:      apiSecret,
-		AllowPublicApi: isPublicApiAllowed,
+		Port:      port,
+		ApiSecret: apiSecret,
 	}
 }
 
 func Default() *Config {
 	return &Config{
-		Port:           defaultPort,
-		ApiSecret:      "",
-		AllowPublicApi: false,
+		Port:      defaultPort,
+		ApiSecret: "",
 	}
 }


### PR DESCRIPTION
I added this `allowPublicApi` parameter to use it without any secrets. But this is not what we want for now.

#### Changes

- Remove `allowPublicApi` parameter from config package
- Update documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the environment variable section in the README.md to remove `ALLOW_PUBLIC_API`, simplifying the setup guide and clarifying the required `API_SECRET`.

- **Bug Fixes**
	- Enhanced error handling for the `apiSecret` parameter during configuration initialization, ensuring the application terminates if the parameter is empty.

- **Refactor**
	- Streamlined the configuration management by removing unnecessary complexity related to public API access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->