### PR TITLE
chore(lint): Add 'golangci-lint' configuration file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  timeout: 1m
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - dogsled
+    - errcheck
+    - errorlint
+    - exhaustive
+    - gocyclo
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - stylecheck
+    - unconvert
+    - unused
+    - whitespace

--- a/Justfile
+++ b/Justfile
@@ -12,6 +12,9 @@ test:
 		-timeout 30s \
 		github.com/bluewave-labs/capture/test
 
+lint:
+	@golangci-lint run
+
 build:
     @go build -o dist/capture ./cmd/capture/
 


### PR DESCRIPTION
### Changes

Use [golangci-lint](https://golangci-lint.run) runner for linting. You should manually [install](https://golangci-lint.run/welcome/install/#local-installation) this tool for running it locally.

We can extend it with github actions easily. [How to use with gh actions](https://github.com/marketplace/actions/golangci-lint#how-to-use)

CodeRabbitAI supports golangci-lint for improving the code review process. [CodeRabbit Supported Tools - golangci-lint](https://docs.coderabbit.ai/tools/golangci-lint)

- [x] Add `.golangci.yml` to configure the runner
- [x] Add `lint` recipe to Justfile



I prefer to solving the linting problems in another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new linting configuration to enhance code quality checks.
	- Added a new target for linting in the build process.

- **Bug Fixes**
	- Updated linting rules to ensure comprehensive static analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->