### PR TITLE
ci: Change 'ubuntu-latest' runners to 'ubuntu-22.04'

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout


### PR DESCRIPTION
Change `ubuntu-latest` runners to `ubuntu-22.04` because ubuntu-latest runners will point to `24.04` soon.

Ref

- https://github.com/actions/runner-images/issues/10636
- https://github.com/bluewave-labs/capture/actions/runs/12454911902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the linting and release workflows to use Ubuntu 22.04 for job execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->