### PR TITLE
fix(metric): collect all disk partitions instead of only physical partitions

### DIFF
--- a/internal/metric/disk.go
+++ b/internal/metric/disk.go
@@ -20,9 +20,8 @@ func CollectDiskMetrics() (MetricsSlice, []CustomErr) {
 	var metricsSlice MetricsSlice
 	var checkedSlice = make([]string, 0, 10) // To keep track of checked partitions
 
-	// Set all flag to "false" to get only necessary partitions
-	// Avoiding unnecessary partitions like /run/user/1000, /run/credentials
-	partitions, partErr := disk.Partitions(false)
+	// Set all flag "true" to get all partitions instead of just physical ones.
+	partitions, partErr := disk.Partitions(true)
 
 	if partErr != nil {
 		diskErrors = append(diskErrors, CustomErr{


### PR DESCRIPTION
## Description of changes

When reading the disks, take all partitions instead of physical partitions to show virtual disk partitions correctly.

## Issue Number

Fix for the #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated disk metrics collection to retrieve all disk partitions instead of filtering specific ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->