### PR TITLE
feat(main): Add version flag to display application version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,10 @@ project_name: capture
 builds:
   - id: capture
     main: ./cmd/capture
+    ldflags:
+      - -s -w
+      - -extldflags "-static"
+      - -X "main.Version={{.Version}}"
     env:
       - CGO_ENABLED=0
     goos:
@@ -34,6 +38,7 @@ kos:
     ldflags:
       - -s -w
       - -extldflags "-static"
+      - -X "main.Version={{.Version}}"
     creation_time: "{{.CommitTimestamp}}"
     sbom: spdx
     env:

--- a/cmd/capture/main.go
+++ b/cmd/capture/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -15,12 +17,26 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-var appConfig = config.NewConfig(
-	os.Getenv("PORT"),
-	os.Getenv("API_SECRET"),
-)
+var appConfig *config.Config
+
+var Version = "develop" // This will be set during compile time using go build ldflags
 
 func main() {
+	showVersion := flag.Bool("version", false, "Display the version of the capture")
+	flag.Parse()
+
+	// Check if the version flag is provided
+	if *showVersion {
+		fmt.Printf("Capture version: %s\n", Version)
+		os.Exit(0)
+	}
+
+	appConfig = config.NewConfig(
+		os.Getenv("PORT"),
+		os.Getenv("API_SECRET"),
+	)
+
+	// Initialize the Gin with default middlewares
 	r := gin.Default()
 	apiV1 := r.Group("/api/v1")
 	apiV1.Use(middleware.AuthRequired(appConfig.APISecret))


### PR DESCRIPTION
## Description of Changes

* Added the `flag` package to handle command-line flags and a new `Version` variable to store the application's version.
* Implemented a version flag (`-version`) that, when used, prints the application's version and exits.

### Configuration initialization refactor:

* Changed the `appConfig` variable from a direct initialization to a pointer and moved its initialization inside the `main` function.

## Issue Number

#41 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line option that displays the application’s version, allowing users to easily identify the current build.

- **Chores**
  - Updated build settings to optimize the executable and reliably embed dynamic version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->