### PR TITLE
fix(ci): Update goreleaser archives formats to accept list

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,14 +44,13 @@ kos:
     env:
       - CGO_ENABLED=0
     bare: true
-    
 
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
 
 checksum:
   # Generate checksum files to confirm the integrity of the files.


### PR DESCRIPTION
GoReleaser `archives.format` is deprecated, now using `archives.formats`

- https://goreleaser.com/deprecations/#archivesformat
- https://goreleaser.com/deprecations/#archivesformat_overridesformat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Archive packaging now supports multiple file formats, providing a broader range of download options. This update improves compatibility and flexibility across various platforms. Users benefit from a richer set of distribution choices, ensuring smoother integration with diverse system requirements and a seamless experience when accessing and deploying release packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->