### PR TITLE
Fix 51 smartctlr metrics od there serve

### DIFF
--- a/cmd/capture/main.go
+++ b/cmd/capture/main.go
@@ -50,6 +50,8 @@ func main() {
 	apiV1.GET("/metrics/memory", handler.MetricsMemory)
 	apiV1.GET("/metrics/disk", handler.MetricsDisk)
 	apiV1.GET("/metrics/host", handler.MetricsHost)
+	apiV1.GET("/metrics/smartmetrics", handler.SmartMetrics)
+
 
 	server := &http.Server{
 		Addr:              ":" + appConfig.Port,

--- a/cmd/capture/main.go
+++ b/cmd/capture/main.go
@@ -50,7 +50,7 @@ func main() {
 	apiV1.GET("/metrics/memory", handler.MetricsMemory)
 	apiV1.GET("/metrics/disk", handler.MetricsDisk)
 	apiV1.GET("/metrics/host", handler.MetricsHost)
-	apiV1.GET("/metrics/smartmetrics", handler.SmartMetrics)
+	apiV1.GET("/metrics/smart", handler.SmartMetrics)
 
 
 	server := &http.Server{

--- a/cmd/capture/main.go
+++ b/cmd/capture/main.go
@@ -52,7 +52,6 @@ func main() {
 	apiV1.GET("/metrics/host", handler.MetricsHost)
 	apiV1.GET("/metrics/smart", handler.SmartMetrics)
 
-
 	server := &http.Server{
 		Addr:              ":" + appConfig.Port,
 		Handler:           r.Handler(),

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -40,3 +40,8 @@ func MetricsHost(c *gin.Context) {
 	hostMetrics, metricsErrs := metric.GetHostInformation()
 	handleMetricResponse(c, hostMetrics, metricsErrs)
 }
+
+func SmartMetrics(c *gin.Context) {
+    smartMetrics, smartErrs := metric.GetSmartMetrics() // Returns []*SmartMetric
+    handleMetricResponse(c, smartMetrics, smartErrs)
+}

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -43,5 +43,5 @@ func MetricsHost(c *gin.Context) {
 
 func SmartMetrics(c *gin.Context) {
     smartMetrics, smartErrs := metric.GetSmartMetrics()
-	handleMetricResponse(c,smartMetrics.Data, append(smartMetrics.Errors, smartErrs...))
+	handleMetricResponse(c,smartMetrics, smartErrs)
 }

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -42,6 +42,6 @@ func MetricsHost(c *gin.Context) {
 }
 
 func SmartMetrics(c *gin.Context) {
-    smartMetrics, smartErrs := metric.GetSmartMetrics() // Returns []*SmartMetric
-    handleMetricResponse(c, smartMetrics, smartErrs)
+    smartMetrics, smartErrs := metric.GetSmartMetrics()
+	handleMetricResponse(c,smartMetrics.Data, append(smartMetrics.Errors, smartErrs...))
 }

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -42,6 +42,6 @@ func MetricsHost(c *gin.Context) {
 }
 
 func SmartMetrics(c *gin.Context) {
-    smartMetrics, smartErrs := metric.GetSmartMetrics()
-	handleMetricResponse(c,smartMetrics, smartErrs)
+	smartMetrics, smartErrs := metric.GetSmartMetrics()
+	handleMetricResponse(c, smartMetrics, smartErrs)
 }

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -13,6 +13,13 @@ type APIResponse struct {
 	Errors []CustomErr `json:"errors"`
 }
 
+type SmartMetric struct {
+	Data   map[string]string `json:"data"`
+	Errors []CustomErr `json:"errors"`
+}
+
+func (s SmartMetric) isMetric() {}
+
 type AllMetrics struct {
 	CPU    CPUData      `json:"cpu"`
 	Memory MemoryData   `json:"memory"`

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -14,11 +14,33 @@ type APIResponse struct {
 }
 
 type SmartMetric struct {
-	Data   map[string]string `json:"data"`
-	Errors []CustomErr `json:"errors"`
+	Data   SmartData    `json:"data"`   // The SMART data
+	Errors []CustomErr  `json:"errors"` // Any errors encountered
 }
 
 func (s SmartMetric) isMetric() {}
+
+type SmartData struct {
+	AvailableSpare                string `json:"available_spare"`
+	AvailableSpareThreshold       string `json:"available_spare_threshold"`
+	ControllerBusyTime            string `json:"controller_busy_time"`
+	CriticalWarning               string `json:"critical_warning"`
+	DataUnitsRead                 string `json:"data_units_read"`
+	DataUnitsWritten              string `json:"data_units_written"`
+	ErrorInformationLogEntries    string `json:"error_information_log_entries"`
+	HostReadCommands              string `json:"host_read_commands"`
+	HostWriteCommands             string `json:"host_write_commands"`
+	MediaAndDataIntegrityErrors  string `json:"media_and_data_integrity_errors"`
+	PercentageUsed                string `json:"percentage_used"`
+	PowerCycles                   string `json:"power_cycles"`
+	PowerOnHours                  string `json:"power_on_hours"`
+	Read1EntriesFromErrorLogFailed string `json:"read_1_entries_from_error_information_log_failed"`
+	SmartOverallHealthResult      string `json:"smart_overall-health_self-assessment_test_result"`
+	Temperature                   string `json:"temperature"`
+	UnsafeShutdowns               string `json:"unsafe_shutdowns"`
+}
+
+func (s SmartData) isMetric() {}
 
 type AllMetrics struct {
 	CPU    CPUData      `json:"cpu"`

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -13,13 +13,6 @@ type APIResponse struct {
 	Errors []CustomErr `json:"errors"`
 }
 
-type SmartMetric struct {
-	Data   SmartData    `json:"data"`   // The SMART data
-	Errors []CustomErr  `json:"errors"` // Any errors encountered
-}
-
-func (s SmartMetric) isMetric() {}
-
 type SmartData struct {
 	AvailableSpare                string `json:"available_spare"`
 	AvailableSpareThreshold       string `json:"available_spare_threshold"`
@@ -27,14 +20,11 @@ type SmartData struct {
 	CriticalWarning               string `json:"critical_warning"`
 	DataUnitsRead                 string `json:"data_units_read"`
 	DataUnitsWritten              string `json:"data_units_written"`
-	ErrorInformationLogEntries    string `json:"error_information_log_entries"`
 	HostReadCommands              string `json:"host_read_commands"`
 	HostWriteCommands             string `json:"host_write_commands"`
-	MediaAndDataIntegrityErrors  string `json:"media_and_data_integrity_errors"`
 	PercentageUsed                string `json:"percentage_used"`
 	PowerCycles                   string `json:"power_cycles"`
 	PowerOnHours                  string `json:"power_on_hours"`
-	Read1EntriesFromErrorLogFailed string `json:"read_1_entries_from_error_information_log_failed"`
 	SmartOverallHealthResult      string `json:"smart_overall-health_self-assessment_test_result"`
 	Temperature                   string `json:"temperature"`
 	UnsafeShutdowns               string `json:"unsafe_shutdowns"`

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -14,20 +14,20 @@ type APIResponse struct {
 }
 
 type SmartData struct {
-	AvailableSpare                string `json:"available_spare"`
-	AvailableSpareThreshold       string `json:"available_spare_threshold"`
-	ControllerBusyTime            string `json:"controller_busy_time"`
-	CriticalWarning               string `json:"critical_warning"`
-	DataUnitsRead                 string `json:"data_units_read"`
-	DataUnitsWritten              string `json:"data_units_written"`
-	HostReadCommands              string `json:"host_read_commands"`
-	HostWriteCommands             string `json:"host_write_commands"`
-	PercentageUsed                string `json:"percentage_used"`
-	PowerCycles                   string `json:"power_cycles"`
-	PowerOnHours                  string `json:"power_on_hours"`
-	SmartOverallHealthResult      string `json:"smart_overall-health_self-assessment_test_result"`
-	Temperature                   string `json:"temperature"`
-	UnsafeShutdowns               string `json:"unsafe_shutdowns"`
+	AvailableSpare           string `json:"available_spare"`
+	AvailableSpareThreshold  string `json:"available_spare_threshold"`
+	ControllerBusyTime       string `json:"controller_busy_time"`
+	CriticalWarning          string `json:"critical_warning"`
+	DataUnitsRead            string `json:"data_units_read"`
+	DataUnitsWritten         string `json:"data_units_written"`
+	HostReadCommands         string `json:"host_read_commands"`
+	HostWriteCommands        string `json:"host_write_commands"`
+	PercentageUsed           string `json:"percentage_used"`
+	PowerCycles              string `json:"power_cycles"`
+	PowerOnHours             string `json:"power_on_hours"`
+	SmartOverallHealthResult string `json:"smart_overall-health_self-assessment_test_result"`
+	Temperature              string `json:"temperature"`
+	UnsafeShutdowns          string `json:"unsafe_shutdowns"`
 }
 
 func (s SmartData) isMetric() {}

--- a/internal/metric/smart_metrics.go
+++ b/internal/metric/smart_metrics.go
@@ -1,6 +1,7 @@
 package metric
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -20,7 +21,7 @@ func checkSmartctlInstalled() error {
 func scanDevices() ([]string, error) {
 	out, err := exec.Command("smartctl", "--scan").Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to scan devices: %v", err)
+		return nil, fmt.Errorf("failed to scan devices: %w", err)
 	}
 
 	var devices []string
@@ -133,10 +134,10 @@ func getMetrics(device string) (*SmartData, []CustomErr) {
 	out, err := cmd.CombinedOutput()
 
 	// If there's an exit error with exit code 4, we ignore the error
-	if exitErr, ok := err.(*exec.ExitError); ok {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
 		switch exitErr.ExitCode() {
 		case 4:
-
 			err = nil
 		case 2:
 			// Exit code 2 indicates permission denied

--- a/internal/metric/smart_metrics.go
+++ b/internal/metric/smart_metrics.go
@@ -1,0 +1,107 @@
+package metric
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// scanDevices returns a list of disks using `smartctl --scan`
+func scanDevices() ([]string, error) {
+	out, err := exec.Command("smartctl", "--scan").Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan devices: %v", err)
+	}
+
+	var devices []string
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			devices = append(devices, fields[0])
+		}
+	}
+	return devices, nil
+}
+
+func parseSmartctlOutput(output string) *SmartMetric {
+	startMarker := "=== START OF SMART DATA SECTION ==="
+	startIdx := strings.Index(output, startMarker)
+	if startIdx == -1 {
+		return &SmartMetric{Data: make(map[string]string)}
+	}
+
+	section := output[startIdx:]
+	endIdx := strings.Index(section, "===")
+	if endIdx > len(startMarker) {
+		section = section[:endIdx]
+	}
+
+	data := make(map[string]string)
+	lines := strings.Split(section, "\n")
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "===") {
+			continue
+		}
+		
+		// Split into key/value pairs
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		
+		// Clean up value: remove extra spaces and brackets
+		value = regexp.MustCompile(`\s+`).ReplaceAllString(value, " ")
+		value = strings.Trim(value, "[]")
+		
+		data[key] = value
+	}
+
+	return &SmartMetric{
+		Data:   data,
+	}
+}
+
+func getMetrics(device string) (*SmartMetric, error) {
+	cmd := exec.Command("smartctl", "-d", "nvme", "--xall", "--nocheck", "standby", device)
+	out, err := cmd.CombinedOutput()
+
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 4 {
+		err = nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("smartctl failed: %v", err)
+	}
+
+	return parseSmartctlOutput(string(out)), nil
+}
+
+func GetSmartMetrics() (MetricsSlice, []CustomErr) { 
+	var smartCtlrErrs []CustomErr
+	devices, err := scanDevices()
+	if err != nil {
+		smartCtlrErrs =append(smartCtlrErrs,CustomErr{
+            Metric: []string{"smart"},
+            Error:  err.Error(),
+        })
+	}
+
+	var metrics MetricsSlice  // Use MetricsSlice instead of []*SmartMetric
+	for _, device := range devices {
+		metric, err := getMetrics(device)
+		if err != nil {
+			log.Printf("Skipping %s: %v", device, err)
+			continue
+		}
+		metrics = append(metrics, metric)
+	}
+
+	return metrics, smartCtlrErrs
+}

--- a/internal/metric/smart_metrics.go
+++ b/internal/metric/smart_metrics.go
@@ -156,7 +156,7 @@ func getMetrics(device string) (*SmartData, []CustomErr) {
 			Error:  fmt.Sprintf("smartctl failed: %v", err),
 		}}
 	}
-	
+
 	return parseSmartctlOutput(string(out))
 }
 

--- a/internal/metric/smart_metrics.go
+++ b/internal/metric/smart_metrics.go
@@ -2,11 +2,20 @@ package metric
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"regexp"
 	"strings"
 )
+
+// Check if smartctl is installed
+func checkSmartctlInstalled() error {
+	cmd := exec.Command("command", "-v", "smartctl")
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("smartctl is not installed")
+	}
+	return nil
+}
 
 // scanDevices returns a list of disks using `smartctl --scan`
 func scanDevices() ([]string, error) {
@@ -26,14 +35,54 @@ func scanDevices() ([]string, error) {
 	return devices, nil
 }
 
+func isErrorKey(key string) bool {
+	loweredKey := strings.ToLower(key)
+	return strings.Contains(loweredKey, "failed") || strings.Contains(loweredKey, "error")
+}
+
+func setField(key, value string, data *SmartData) {
+	switch strings.ToLower(key) {
+	case "available spare":
+		data.AvailableSpare = value
+	case "available spare threshold":
+		data.AvailableSpareThreshold = value
+	case "controller busy time":
+		data.ControllerBusyTime = value
+	case "critical warning":
+		data.CriticalWarning = value
+	case "data units read":
+		data.DataUnitsRead = value
+	case "data units written":
+		data.DataUnitsWritten = value
+	case "host read commands":
+		data.HostReadCommands = value
+	case "host write commands":
+		data.HostWriteCommands = value
+	case "percentage used":
+		data.PercentageUsed = value
+	case "power cycles":
+		data.PowerCycles = value
+	case "power on hours":
+		data.PowerOnHours = value
+	case "smart overall-health self-assessment test result":
+		data.SmartOverallHealthResult = value
+	case "temperature":
+		data.Temperature = value
+	case "unsafe shutdowns":
+		data.UnsafeShutdowns = value
+	}
+}
+
 // parseSmartctlOutput parses the output from smartctl command
-func parseSmartctlOutput(output string) *SmartMetric {
+func parseSmartctlOutput(output string) (*SmartData, []CustomErr) {
+	// Define the start marker to locate the section of interest
 	startMarker := "=== START OF SMART DATA SECTION ==="
 	startIdx := strings.Index(output, startMarker)
 	if startIdx == -1 {
-		return &SmartMetric{Data: SmartData{}, Errors: []CustomErr{}}
+		return &SmartData{}, nil
 	}
 
+	// Extract the section starting from the marker
 	section := output[startIdx:]
 	endIdx := strings.Index(section, "===")
 	if endIdx > len(startMarker) {
@@ -42,14 +91,17 @@ func parseSmartctlOutput(output string) *SmartMetric {
 
 	data := SmartData{}
 	var errors []CustomErr
+
+	// Split the section into lines
 	lines := strings.Split(section, "\n")
 
 	for _, line := range lines {
+		// Skip empty lines or lines starting with "==="
 		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "===") {
 			continue
 		}
-		
-		// Split into key/value pairs
+
+		// Split each line into a key-value pair
 		parts := strings.SplitN(line, ":", 2)
 		if len(parts) != 2 {
 			continue
@@ -57,50 +109,16 @@ func parseSmartctlOutput(output string) *SmartMetric {
 
 		key := strings.TrimSpace(parts[0])
 		value := strings.TrimSpace(parts[1])
-		
-		// Clean up value: remove extra spaces and brackets
+
+		// Clean up value by removing extra spaces and brackets
 		value = regexp.MustCompile(`\s+`).ReplaceAllString(value, " ")
 		value = strings.Trim(value, "[]")
 
-		switch strings.ToLower(key) {
-		case "available spare":
-			data.AvailableSpare = value
-		case "available spare threshold":
-			data.AvailableSpareThreshold = value
-		case "controller busy time":
-			data.ControllerBusyTime = value
-		case "critical warning":
-			data.CriticalWarning = value
-		case "data units read":
-			data.DataUnitsRead = value
-		case "data units written":
-			data.DataUnitsWritten = value
-		case "error information log entries":
-			data.ErrorInformationLogEntries = value
-		case "host read commands":
-			data.HostReadCommands = value
-		case "host write commands":
-			data.HostWriteCommands = value
-		case "media and data integrity errors":
-			data.MediaAndDataIntegrityErrors = value
-		case "percentage used":
-			data.PercentageUsed = value
-		case "power cycles":
-			data.PowerCycles = value
-		case "power on hours":
-			data.PowerOnHours = value
-		case "read 1 entries from error information log failed":
-			data.Read1EntriesFromErrorLogFailed = value
-		case "smart overall-health self-assessment test result":
-			data.SmartOverallHealthResult = value
-		case "temperature":
-			data.Temperature = value
-		case "unsafe shutdowns":
-			data.UnsafeShutdowns = value
-		}
+		// Set the field in the SmartData struct
+		setField(key, value, &data)
 
 		// If the key contains "error" or "failed", add it to the errors
-		if strings.Contains(key, "failed") || strings.Contains(key, "error") {
+		if isErrorKey(key) {
 			errors = append(errors, CustomErr{
 				Metric: []string{key},
 				Error:  fmt.Sprintf("Unable to retrieve the '%s'", key),
@@ -108,47 +126,69 @@ func parseSmartctlOutput(output string) *SmartMetric {
 		}
 	}
 
-	return &SmartMetric{
-		Data:   data,
-		Errors: errors,
-	}
+	return &data, errors
 }
 
-func getMetrics(device string) (*SmartMetric, error) {
+func getMetrics(device string) (*SmartData, []CustomErr) {
 	cmd := exec.Command("smartctl", "-d", "nvme", "--xall", "--nocheck", "standby", device)
 	out, err := cmd.CombinedOutput()
 
+	// If there's an exit error with exit code 4, we ignore the error
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 4 {
 		err = nil
 	}
 
+	// If there's an error executing the command, return empty SmartData and the error
 	if err != nil {
-		return nil, fmt.Errorf("smartctl failed: %v", err)
+		return &SmartData{}, []CustomErr{{
+			Metric: []string{"smartctl"},
+			Error:  fmt.Sprintf("smartctl failed: %v", err),
+		}}
 	}
 
-	return parseSmartctlOutput(string(out)), nil
+	// Parse the output from smartctl
+	metric, errs := parseSmartctlOutput(string(out))
+
+	// Return the parsed SmartData and the errors
+	return metric, errs
 }
 
 // GetSmartMetrics retrieves the SMART metrics from all available devices.
-func GetSmartMetrics() (SmartMetric, []CustomErr) {
+func GetSmartMetrics() (SmartData, []CustomErr) {
+	var metrics SmartData
 	var smartCtlrErrs []CustomErr
-	devices, err := scanDevices()
-	if err != nil {
+
+	// Check if smartctl is installed
+	if err := checkSmartctlInstalled(); err != nil {
 		smartCtlrErrs = append(smartCtlrErrs, CustomErr{
-			Metric: []string{"smart"},
+			Metric: []string{"smartctl"},
 			Error:  err.Error(),
 		})
+		return metrics, smartCtlrErrs
+	}
+	// Scan for devices
+	devices, devicesErr := scanDevices()
+	if devicesErr != nil {
+		// Return the error if the scan fails
+		smartCtlrErrs = append(smartCtlrErrs, CustomErr{
+			Metric: []string{"smart"},
+			Error:  devicesErr.Error(),
+		})
+		return metrics, smartCtlrErrs
 	}
 
-	var metrics SmartMetric
+	// Iterate over devices and collect metrics
 	for _, device := range devices {
-		metric, err := getMetrics(device)
-		if err != nil {
-			log.Printf("Skipping %s: %v", device, err)
-			continue
+		metric, metricErr := getMetrics(device)
+
+		if metric != nil {
+			metrics = *metric
 		}
-	
-		metrics = *metric
+
+		if len(metricErr) > 0 {
+			smartCtlrErrs = append(smartCtlrErrs, metricErr...)
+		}
 	}
+
 	return metrics, smartCtlrErrs
 }


### PR DESCRIPTION
Sample out put of the api end point `/api/v1/metrics/smart`.

```
{
    "data": {
        "available_spare": "100%",
        "available_spare_threshold": "99%",
        "controller_busy_time": "0",
        "critical_warning": "0x00",
        "data_units_read": "513,796,561 [263 TB",
        "data_units_written": "496,894,877 [254 TB",
        "error_information_log_entries": "0",
        "host_read_commands": "3,535,749,949",
        "host_write_commands": "2,633,648,374",
        "media_and_data_integrity_errors": "0",
        "percentage_used": "4%",
        "power_cycles": "241",
        "power_on_hours": "2,332",
        "read_1_entries_from_error_information_log_failed": "GetLogPage failed: system=0x38, sub=0x0, code=745",
        "smart_overall-health_self-assessment_test_result": "PASSED",
        "temperature": "36 Celsius",
        "unsafe_shutdowns": "142"
    },
    "errors": [
        {
            "metric": [
                "Read 1 entries from Error Information Log failed"
            ],
            "err": "Unable to retrieve the 'Read 1 entries from Error Information Log failed'"
        }
    ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint for accessing smart metrics, enhancing system metrics reporting.
	- Users can now benefit from detailed disk health reporting, providing improved insights into system performance and reliability.
	- Added functionality to retrieve and parse SMART metrics from disk devices using the `smartctl` utility.
	- New data structure for representing SMART metrics has been implemented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->