### PR TITLE
build(macos): Allow building pre-built binaries for MacOS(darwin)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,9 +12,9 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      # Disable windows and darwin builds for now, because the app is not working on these platforms
+      - darwin
+      # Disable Windows builds for now, because Capture is not working on windows properly
       # - windows
-      # - darwin
     goarch:
       # Support multiple cpu architectures
       - amd64

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 
 Capture is a hardware monitoring agent that collects hardware information from the host machine and exposes it through a RESTful API. The agent is designed to be lightweight and easy to use.
 
-Capture is only available for **Linux**.
-
 ## Docker Installation
 
 Docker installation is **recommended** for running the Capture. Please see the [Docker run flags](#docker-run-flags) section for more information.


### PR DESCRIPTION
We can provide pre-built binaries for MacOS, the next release may include MacOS builds.