### PR TITLE
fix(disk): Enhance partition filtering to include ZFS filesystems

### DIFF
--- a/internal/metric/disk.go
+++ b/internal/metric/disk.go
@@ -40,10 +40,11 @@ func CollectDiskMetrics() (MetricsSlice, []CustomErr) {
 	}
 
 	for _, p := range partitions {
-		// Filter out partitions that are already checked or not a device
-		// Also, exclude '/dev/loop' devices to avoid unnecessary partitions
-		// * /dev/loop devices are used for mounting snap packages
-		if slices.Contains(checkedSlice, p.Device) || !strings.HasPrefix(p.Device, "/dev") || strings.HasPrefix(p.Device, "/dev/loop") {
+		// Filter out partitions that are already checked or loop devices
+		// Include both /dev devices (except loops) and ZFS filesystems
+		// * ZFS filesystems are not prefixed with /dev, so we check for that separately
+		if slices.Contains(checkedSlice, p.Device) ||
+			(strings.Contains(p.Device, "/dev/loop") || (!strings.HasPrefix(p.Device, "/dev") && p.Fstype != "zfs")) {
 			continue
 		}
 


### PR DESCRIPTION
Issue: #55 

Updated the filtering logic to include ZFS filesystems, which are not prefixed with `/dev`, while continuing to exclude `/dev/loop` devices. This improves support for ZFS-based systems and refines the partition selection process.

## How to test

shell:bash

```bash
truncate -s 100M zfs.img
LOOP=$(losetup -f --show zfs.img)

zpool create mypool "${LOOP}"
zfs create mypool/myfs
touch /mypool/myfs/hello.txt
```

Your `df -h` output will be like that

```shell
....
mypool           40M  128K   40M   1% /mypool
mypool/myfs      40M  128K   40M   1% /mypool/myfs
```

Run the capture and go to `http://localhost:59232/api/v1/metrics/disk` endpoint. It will show the `mypool` and `mypool/myfs`


If everything is ok, you can delete the pool and loop device

```shell
zpool export mypool
losetup -d "${LOOP}"
```

