### PR TITLE
chore: Add .air.toml configuration for live reload in development

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,15 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  bin = "./tmp/capture"
+  cmd = "go build -o ./tmp/capture ./cmd/capture/"
+  include_dir = ["cmd", "internal", "pkg"]
+  include_ext = ["go"]
+  exclude_dir = ["docs", "vendor", "test"]
+  stop_on_error = false
+  rerun_delay = 0
+
+[misc]
+  # Delete tmp directory on exit
+  clean_on_exit = true

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+dist
 
 # Test binary, built with `go test -c`
 *.test
@@ -23,5 +24,9 @@ go.work.sum
 
 # env file
 .env
+
+# Editor directories
 .idea
-dist
+
+# air-verse/air tmp directory
+tmp


### PR DESCRIPTION
Add `.air.toml` configuration for build process and update .gitignore to include 'dist' and 'tmp' directories

Air: https://github.com/air-verse/air

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new configuration file for build and development tool settings.
	- Updated ignored files and directories to include build output and temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->