### PR TITLE
docs(security): Update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,12 @@
 # Security Policy
 
-If you find a vulnerability, send it to hello@bluewavelabs.ca
+## Reporting a Vulnerability
 
-Please do not create an issue for security vulnerabilities.
+To report a potential security vulnerability, please use the [GitHub private vulnerability reporting feature](https://github.com/bluewave-labs/capture/security/advisories/new).
+
+For us to respond to your report most effectively, please include:
+
+- Steps to reproduce or a proof-of-concept.
+- Relevant information, such as the versions of `capture` and any dependencies used.
+
+Thank you for helping us maintain a secure and reliable project!


### PR DESCRIPTION
## Changes

- Update vulnerability reporting guideline to point "GitHub Private Vulnerability Reporting" feature.

---

We can also use the similar format for the other repositories under the BlueWave Labs.