### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/capture/security/code-scanning/2](https://github.com/bluewave-labs/capture/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow only requires read access to the repository contents (e.g., for checking out the code), we will set `contents: read` as the minimal required permission. This change ensures that the `GITHUB_TOKEN` is restricted to the least privilege necessary for the workflow to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
