### PR TITLE
chore: Add support for armv6 and armv7 architecture in GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,10 @@ builds:
       # Support multiple cpu architectures
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
     ignore:
       # Ignore the arm64 build on windows
       - goos: windows


### PR DESCRIPTION
We should add `arm32` support for some early Raspberry Pi devices.

- [x] Add `armv6`, `armv7` archives to GitHub releases.

### To Do

- [ ] Can we publish a docker image for linux/arm32 with GoReleaser?