### PR TITLE
feat(metrics): Show capture version in API response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ You can build the Capture from the source code.
 
 Configure the capture with the following environment variables:
 
-| Variable     | Description                          | Required/Optional |
-| ------------ | ------------------------------------ | ----------------- |
-| `PORT`       | The port that the Capture listens on | Optional          |
-| `API_SECRET` | The secret key for the API           | Required          |
-| `GIN_MODE`   | The mode of the Gin framework        | Optional          |
+| Variable      | Description                           | Required/Optional |
+| ------------- | ------------------------------------- | ----------------- |
+| `PORT`        | The port that the Capture listens on  | Optional          |
+| `API_SECRET`  | The secret key for the API            | Required          |
+| `GIN_MODE`    | The mode of the Gin framework         | Optional          |
+| `VERSION`     | The App Version                       | Optional          |
 
 ### Example
 
@@ -138,11 +139,12 @@ Please make sure to replace the default `your_secret` with your own secret.
 PORT = your_port
 API_SECRET = your_secret
 GIN_MODE = release/debug
+VERSION = 1.1.0
 ```
 
 ```shell
 # API_SECRET is required
-API_SECRET=your_secret GIN_MODE=release ./capture
+API_SECRET=your_secret GIN_MODE=release VERSION=1.1.0 ./capture
 
 # Minimal required configuration
 API_SECRET=your_secret ./dist/capture

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -1,5 +1,9 @@
 package metric
 
+import (
+	"os"
+)
+
 type MetricsSlice []Metric
 
 func (m MetricsSlice) isMetric() {}
@@ -9,8 +13,21 @@ type Metric interface {
 }
 
 type APIResponse struct {
-	Data   Metric      `json:"data"`
-	Errors []CustomErr `json:"errors"`
+	Data   	Metric      `json:"data"`
+	Capture CaptureMeta `json:"capture"`
+	Errors 	[]CustomErr `json:"errors"`
+}
+
+type CaptureMeta struct {
+	Version	string `json:"version"`
+	Mode		string `json:"mode"`
+}
+
+func GetCaptureVersionMetdata() CaptureMeta {
+	return CaptureMeta{
+		Version: os.Getenv("VERSION"),
+		Mode:    os.Getenv("GIN_MODE"),
+	}
 }
 
 type SmartData struct {

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -1,8 +1,6 @@
 package metric
 
-import (
-	"os"
-)
+import "os"
 
 type MetricsSlice []Metric
 
@@ -24,9 +22,19 @@ type CaptureMeta struct {
 }
 
 func GetCaptureVersionMetdata() CaptureMeta {
+	version := os.Getenv("VERSION")
+	if version == "" {
+		version = "unknown"
+	}
+
+	mode := os.Getenv("GIN_MODE")
+	if mode == "" {
+		mode = "release"
+	}
+
 	return CaptureMeta{
-		Version: os.Getenv("VERSION"),
-		Mode:    os.Getenv("GIN_MODE"),
+		Version: version,
+		Mode:    mode,
 	}
 }
 

--- a/internal/server/handler/metrics.go
+++ b/internal/server/handler/metrics.go
@@ -12,6 +12,7 @@ func handleMetricResponse(c *gin.Context, metrics metric.Metric, errs []metric.C
 	}
 	c.JSON(statusCode, metric.APIResponse{
 		Data:   metrics,
+		Capture: metric.GetCaptureVersionMetdata(),
 		Errors: errs,
 	})
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -147,6 +147,13 @@ components:
                 $ref: '#/components/schemas/DiskData'
             host:
               $ref: '#/components/schemas/HostData'
+        capture:
+          type: object
+          properties:
+            version:
+              type: string
+            mode:
+              type: string
         errors:
           type: array
           nullable: true
@@ -230,7 +237,7 @@ components:
         usage_percent:
           type: number
           example: 0.2601
-    DiskData: 
+    DiskData:
       type: object
       properties:
         device:


### PR DESCRIPTION
Closes #68 
![image](https://github.com/user-attachments/assets/5e901f8f-baba-4dfb-abd5-e10b17da00f9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The metrics API response now includes capture environment metadata, displaying the application's version and mode.
- **Documentation**
	- Updated documentation to describe the new `VERSION` environment variable and its usage in configuration examples.
	- OpenAPI specification updated to reflect the new `capture` metadata in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->