### PR TITLE
fix: Move health check route to the correct position in the handler initialization

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -57,11 +57,11 @@ func InitializeHandler(config *config.Config) http.Handler {
 	} else {
 		println("running in Debug Mode")
 	}
+	// Health Check
+	r.GET("/health", handler.Health)
+
 	apiV1 := r.Group("/api/v1")
 	apiV1.Use(middleware.AuthRequired(config.APISecret))
-
-	// Health Check
-	apiV1.GET("/health", handler.Health)
 
 	// Metrics
 	apiV1.GET("/metrics", handler.Metrics)


### PR DESCRIPTION
Move health check endpoint from `/api/v1/health` to `/health` to check health without any authorization logic. This will help to create one line health check commands in the Dockerfile like `curl -f http://localhost:59232/health || exit 1`