### PR TITLE
Add support for OS Pretty Name in Host Metric

### DIFF
--- a/internal/metric/host.go
+++ b/internal/metric/host.go
@@ -1,6 +1,11 @@
 package metric
 
 import (
+	"bufio"
+	"errors"
+	"os"
+	"strings"
+
 	"github.com/shirou/gopsutil/v4/host"
 )
 
@@ -10,6 +15,7 @@ func GetHostInformation() (*HostData, []CustomErr) {
 		Os:            "unknown",
 		Platform:      "unknown",
 		KernelVersion: "unknown",
+		PrettyName:    "unknown",
 	}
 	info, infoErr := host.Info()
 
@@ -21,9 +27,44 @@ func GetHostInformation() (*HostData, []CustomErr) {
 		return &defaultHostData, hostErrors
 	}
 
+	prettyName, prettyErr := GetPrettyName()
+	if prettyErr != nil {
+		hostErrors = append(hostErrors, CustomErr{
+			Metric: []string{"host.pretty_name"},
+			Error:  prettyErr.Error(),
+		})
+		prettyName = "unknown"
+	}
+
 	return &HostData{
 		Os:            info.OS,
 		Platform:      info.Platform,
 		KernelVersion: info.KernelVersion,
+		PrettyName:    prettyName,
 	}, hostErrors
+}
+
+func GetPrettyName() (string, error) {
+	const osReleasePath = "/etc/os-release"
+
+	file, err := os.Open(osReleasePath)
+	if err != nil {
+		return "", errors.New("unable to open /etc/os-release: " + err.Error())
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "PRETTY_NAME=") {
+			pretty := strings.TrimPrefix(line, "PRETTY_NAME=")
+			return strings.Trim(pretty, `"`), nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", errors.New("error reading /etc/os-release: " + err.Error())
+	}
+
+	return "", errors.New("PRETTY_NAME field not found in /etc/os-release")
 }

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -85,6 +85,7 @@ type HostData struct {
 	Os            string `json:"os"`             // Operating System
 	Platform      string `json:"platform"`       // Platform Name
 	KernelVersion string `json:"kernel_version"` // Kernel Version
+	PrettyName    string `json:"pretty_name"`    // Pretty OS Name from /etc/os-release
 }
 
 func (h HostData) isMetric() {}


### PR DESCRIPTION
Description:

- This PR enhances the host metrics collection by adding support for PrettyName, which is parsed from /etc/os-release.
- If available, the value is included in the HostData returned by the `/api/v1/metrics` endpoint.
- Errors during parsing (e.g., missing file or field) are gracefully handled and returned as part of the response.

Changes:

- Added PrettyName field to HostData struct
- Implemented GetPrettyName() to read from /etc/os-release
- Updated GetHostInformation() to populate PrettyName
- Extended error handling to include parsing issues


This PR addresses feature - https://github.com/bluewave-labs/capture/issues/22
