### PR TITLE
feat: implement GetPrettyName for macOS, Linux, and Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/mstrYoda/go-arctest v0.0.0-20250422073853-ff9fe79f31d7
 	github.com/shirou/gopsutil/v4 v4.24.9
+	golang.org/x/sys v0.33.0
 )
 
 require (
@@ -61,7 +62,6 @@ require (
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/internal/metric/host.go
+++ b/internal/metric/host.go
@@ -1,11 +1,6 @@
 package metric
 
 import (
-	"bufio"
-	"errors"
-	"os"
-	"strings"
-
 	"github.com/shirou/gopsutil/v4/host"
 )
 
@@ -42,29 +37,4 @@ func GetHostInformation() (*HostData, []CustomErr) {
 		KernelVersion: info.KernelVersion,
 		PrettyName:    prettyName,
 	}, hostErrors
-}
-
-func GetPrettyName() (string, error) {
-	const osReleasePath = "/etc/os-release"
-
-	file, err := os.Open(osReleasePath)
-	if err != nil {
-		return "", errors.New("unable to open /etc/os-release: " + err.Error())
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "PRETTY_NAME=") {
-			pretty := strings.TrimPrefix(line, "PRETTY_NAME=")
-			return strings.Trim(pretty, `"`), nil
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", errors.New("error reading /etc/os-release: " + err.Error())
-	}
-
-	return "", errors.New("PRETTY_NAME field not found in /etc/os-release")
 }

--- a/internal/metric/host_darwin.go
+++ b/internal/metric/host_darwin.go
@@ -1,0 +1,41 @@
+//go:build darwin
+// +build darwin
+
+package metric
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func GetPrettyName() (string, error) {
+	cmd := exec.Command("sw_vers")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	output := out.String()
+
+	var productName, productVersion string
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if trimmed, found := strings.CutPrefix(line, "ProductName:"); found {
+			productName = strings.TrimSpace(trimmed)
+		} else if trimmed, found := strings.CutPrefix(line, "ProductVersion:"); found {
+			productVersion = strings.TrimSpace(trimmed)
+		}
+	}
+
+	if productName != "" && productVersion != "" {
+		return fmt.Sprintf("%s %s", productName, productVersion), nil
+	}
+
+	return "", fmt.Errorf("could not determine macOS version")
+}

--- a/internal/metric/host_linux.go
+++ b/internal/metric/host_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+// +build linux
+
+package metric
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"strings"
+)
+
+func GetPrettyName() (string, error) {
+	const osReleasePath = "/etc/os-release"
+
+	file, err := os.Open(osReleasePath)
+	if err != nil {
+		return "", errors.New("unable to open /etc/os-release: " + err.Error())
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "PRETTY_NAME=") {
+			pretty := strings.TrimPrefix(line, "PRETTY_NAME=")
+			return strings.Trim(pretty, `"`), nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", errors.New("error reading /etc/os-release: " + err.Error())
+	}
+
+	return "", errors.New("PRETTY_NAME field not found in /etc/os-release")
+}

--- a/internal/metric/host_windows.go
+++ b/internal/metric/host_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+package metric
+
+import (
+	"golang.org/x/sys/windows/registry"
+)
+
+func GetPrettyName() (string, error) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return "", err
+	}
+	defer key.Close()
+
+	productName, _, err := key.GetStringValue("ProductName")
+	if err != nil {
+		return "", err
+	}
+
+	return productName, nil
+}


### PR DESCRIPTION
Task: #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving a human-readable operating system name on macOS, Linux, and Windows platforms.

* **Refactor**
  * Improved platform-specific handling by separating OS detection logic into dedicated files for each operating system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->