### PR TITLE
build: Ignore arm(arm32) architecture on Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,11 @@ builds:
     goarm:
       - 6
       - 7
+    ignore:
+      # Ignore the arm(arm32) architecture Windows
+      # Still supporting the arm64 architecture for Windows + Raspberry Pi combo and other development environments like arm64 laptops.
+      - goos: windows
+        goarch: arm
 
 kos:
   - id: capture


### PR DESCRIPTION
## Ignore arm(arm32) architecture on Windows

Ignore the arm(arm32) architecture Windows because it's not that common. We should keep the artifact list clean. Still supporting the arm64 architecture for Windows + Raspberry Pi combo and other development environments like arm64 laptops.  

If there is demand from users for ARM32 on Windows, we can consider supporting it. If you're interested, please feel free to [open an issue](https://github.com/bluewave-labs/capture/issues/new/choose) and let us know.