### PR TITLE
fix(linux-cpu): cover CPU temperature sensors without label files

### DIFF
--- a/internal/system/cpu_linux.go
+++ b/internal/system/cpu_linux.go
@@ -52,17 +52,15 @@ func isValidCPUTempSensor(path string) bool {
 		return true
 	}
 
-	// For hwmon paths, check the label if it exists
 	labelPath := strings.Replace(path, "_input", "_label", 1)
-	if label, err := os.ReadFile(labelPath); err == nil {
-		labelStr := strings.ToLower(strings.TrimSpace(string(label)))
-		// Only process if it's a core or tctl (AMD temperature control value)
-		return strings.Contains(labelStr, "core") || strings.Contains(labelStr, "tctl")
+	label, err := os.ReadFile(labelPath)
+	if err != nil {
+		// No label file exists, assume it could be a CPU temperature sensor
+		return true
 	}
 
-	// No label file exists, assume it could be a CPU temperature sensor
-	// This handles cases where hwmon devices don't provide labels but still contain valid CPU temp data
-	return true
+	labelStr := strings.ToLower(strings.TrimSpace(string(label)))
+	return strings.Contains(labelStr, "core") || strings.Contains(labelStr, "tctl")
 }
 
 // addTemperatureIfValid reads temperature from path and adds it to temps slice if successful
@@ -112,6 +110,6 @@ func CPUCurrentFrequency() (int, error) {
 		return 0, cpuFrequencyError
 	}
 
-	// Convert frequency to mHz
+	// Convert kHz to MHz
 	return frequency / 1000, nil
 }

--- a/internal/system/cpu_linux.go
+++ b/internal/system/cpu_linux.go
@@ -47,8 +47,9 @@ func readCPUFreqFile(path string) (int, error) {
 func CPUTemperature() ([]float32, error) {
 	// Look in all these folders for core temp
 	corePaths := []string{
-		"/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp*_input",
-		"/sys/class/hwmon/hwmon*/temp*_input",
+		"/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp*_input", // hwmon
+		"/sys/class/hwmon/hwmon*/temp*_input",                       // hwmon
+		"/sys/class/thermal/thermal_zone0/temp",                     // thermal_zone
 	}
 
 	var temps []float32
@@ -61,16 +62,24 @@ func CPUTemperature() ([]float32, error) {
 		}
 		// Loop over temp_input paths
 		for _, path := range matches {
-			// Look in the corresponding label to see if this is a core temp
-			labelPath := strings.Replace(path, "_input", "_label", 1)
-			if label, err := os.ReadFile(labelPath); err == nil {
-				labelStr := strings.ToLower(strings.TrimSpace(string(label)))
-				// Only process if it's a core
-				// * tctl is the temperature control value for AMD processors. We should also consider it as a core temperature.
-				if strings.Contains(labelStr, "core") || strings.Contains(labelStr, "tctl") {
-					if temp, err := readTempFile(path); err == nil {
-						temps = append(temps, temp)
+			// For hwmon paths, check the label to see if this is a core temp
+			if strings.Contains(path, "hwmon") {
+				labelPath := strings.Replace(path, "_input", "_label", 1)
+				if label, err := os.ReadFile(labelPath); err == nil {
+					labelStr := strings.ToLower(strings.TrimSpace(string(label)))
+
+					// Only process if it's a core
+					// * tctl is the temperature control value for AMD processors. We should also consider it as a core temperature.
+					if strings.Contains(labelStr, "core") || strings.Contains(labelStr, "tctl") {
+						if temp, err := readTempFile(path); err == nil {
+							temps = append(temps, temp)
+						}
 					}
+				}
+			} else {
+				// For non-hwmon paths (like thermal_zone), read directly
+				if temp, err := readTempFile(path); err == nil {
+					temps = append(temps, temp)
 				}
 			}
 		}

--- a/internal/system/cpu_linux.go
+++ b/internal/system/cpu_linux.go
@@ -78,7 +78,7 @@ func CPUTemperature() ([]float32, error) {
 	corePaths := []string{
 		"/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp*_input", // hwmon
 		"/sys/class/hwmon/hwmon*/temp*_input",                       // hwmon
-		// "/sys/class/thermal/thermal_zone0/temp",                     // thermal_zone. it's the same of /sys/class/hwmon/hwmon0/temp1_input
+		// "/sys/class/thermal/thermal_zone0/temp",                     // thermal_zone. it's the same as /sys/class/hwmon/hwmon0/temp1_input
 	}
 
 	var temps []float32

--- a/internal/system/cpu_linux.go
+++ b/internal/system/cpu_linux.go
@@ -15,6 +15,7 @@ var (
 	ErrCPUDetailsNotImplemented = errors.New("CPU details not implemented on linux")
 )
 
+// readTempFile reads a temperature file and returns the temperature in Celsius.
 func readTempFile(path string) (float32, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -29,6 +30,7 @@ func readTempFile(path string) (float32, error) {
 	return float32(temp) / 1000, nil
 }
 
+// readCPUFreqFile reads a CPU frequency file and returns the frequency in kHz.
 func readCPUFreqFile(path string) (int, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -43,13 +45,40 @@ func readCPUFreqFile(path string) (int, error) {
 	return freq, nil
 }
 
+// isValidCPUTempSensor determines if a temperature sensor should be considered for CPU temperature reading
+func isValidCPUTempSensor(path string) bool {
+	if !strings.Contains(path, "hwmon") {
+		// For non-hwmon paths (like thermal_zone), assume valid
+		return true
+	}
+
+	// For hwmon paths, check the label if it exists
+	labelPath := strings.Replace(path, "_input", "_label", 1)
+	if label, err := os.ReadFile(labelPath); err == nil {
+		labelStr := strings.ToLower(strings.TrimSpace(string(label)))
+		// Only process if it's a core or tctl (AMD temperature control value)
+		return strings.Contains(labelStr, "core") || strings.Contains(labelStr, "tctl")
+	}
+
+	// No label file exists, assume it could be a CPU temperature sensor
+	// This handles cases where hwmon devices don't provide labels but still contain valid CPU temp data
+	return true
+}
+
+// addTemperatureIfValid reads temperature from path and adds it to temps slice if successful
+func addTemperatureIfValid(path string, temps *[]float32) {
+	if temp, err := readTempFile(path); err == nil {
+		*temps = append(*temps, temp)
+	}
+}
+
 // CPUTemperature returns the temperature of CPU cores in Celsius.
 func CPUTemperature() ([]float32, error) {
 	// Look in all these folders for core temp
 	corePaths := []string{
 		"/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp*_input", // hwmon
 		"/sys/class/hwmon/hwmon*/temp*_input",                       // hwmon
-		"/sys/class/thermal/thermal_zone0/temp",                     // thermal_zone
+		// "/sys/class/thermal/thermal_zone0/temp",                     // thermal_zone. it's the same of /sys/class/hwmon/hwmon0/temp1_input
 	}
 
 	var temps []float32
@@ -60,27 +89,11 @@ func CPUTemperature() ([]float32, error) {
 		if err != nil { // Keep looking for matches if we get an error
 			continue
 		}
+
 		// Loop over temp_input paths
 		for _, path := range matches {
-			// For hwmon paths, check the label to see if this is a core temp
-			if strings.Contains(path, "hwmon") {
-				labelPath := strings.Replace(path, "_input", "_label", 1)
-				if label, err := os.ReadFile(labelPath); err == nil {
-					labelStr := strings.ToLower(strings.TrimSpace(string(label)))
-
-					// Only process if it's a core
-					// * tctl is the temperature control value for AMD processors. We should also consider it as a core temperature.
-					if strings.Contains(labelStr, "core") || strings.Contains(labelStr, "tctl") {
-						if temp, err := readTempFile(path); err == nil {
-							temps = append(temps, temp)
-						}
-					}
-				}
-			} else {
-				// For non-hwmon paths (like thermal_zone), read directly
-				if temp, err := readTempFile(path); err == nil {
-					temps = append(temps, temp)
-				}
+			if isValidCPUTempSensor(path) {
+				addTemperatureIfValid(path, &temps)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

On `system/cpu`, when no label file exists it now assumes the temperature sensor could be a valid CPU temperature sensor and includes it in the results.

Effected Devices:

  - Raspberry Pi 4,5

## Changes

- Add `isValidCPUTempSensor` helper function to determine valid paths
- Add `addTemperatureIfValid` helper function to add temperature value to temp slice
- Add missing go doc comments

## Fixes(Potentially)

- #100 